### PR TITLE
Fix translation overlay across Spaces

### DIFF
--- a/SnapTra Translator/AppModel.swift
+++ b/SnapTra Translator/AppModel.swift
@@ -2469,6 +2469,12 @@ final class AppModel: ObservableObject {
 
         let workspaceNotifications = NSWorkspace.shared.notificationCenter
 
+        workspaceNotifications.publisher(for: NSWorkspace.activeSpaceDidChangeNotification)
+            .sink { [weak self] _ in
+                self?.handleActiveSpaceChange()
+            }
+            .store(in: &cancellables)
+
         workspaceNotifications.publisher(for: NSWorkspace.willSleepNotification)
             .sink { [weak self] _ in
                 self?.prepareForSystemSleep()
@@ -2504,6 +2510,19 @@ final class AppModel: ObservableObject {
                 self?.handleScreenConfigurationChange()
             }
             .store(in: &cancellables)
+    }
+
+    private func handleActiveSpaceChange() {
+        captureService.invalidateCache()
+
+        guard isHotkeyActive || isParagraphOverlayPresented || isTapKeptOverlayPresented else {
+            return
+        }
+
+        // Reassert the all-Spaces panel after Mission Control changes the
+        // active Space. The next OCR result will then be ordered in the new
+        // Space instead of being treated as already visible elsewhere.
+        overlayWindowController.reassertForActiveSpace()
     }
 
     private func prepareForSystemSleep() {

--- a/SnapTra Translator/OverlayWindowController.swift
+++ b/SnapTra Translator/OverlayWindowController.swift
@@ -1172,6 +1172,12 @@ enum ParagraphOverlayLayout {
 // MARK: - Overlay Window Controller
 
 final class OverlayWindowController: NSWindowController {
+    private static let allSpacesCollectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllSpaces,
+        .fullScreenAuxiliary,
+        .stationary,
+    ]
+
     private let model: AppModel
     private let hostingView: NSHostingView<AnyView>
     private var measurementHostingView: NSHostingView<AnyView>?
@@ -1211,7 +1217,7 @@ final class OverlayWindowController: NSWindowController {
         panel.backgroundColor = .clear
         panel.hasShadow = false
         panel.level = .screenSaver
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.collectionBehavior = Self.allSpacesCollectionBehavior
         panel.ignoresMouseEvents = true
         panel.isMovableByWindowBackground = false
         super.init(window: panel)
@@ -1240,11 +1246,22 @@ final class OverlayWindowController: NSWindowController {
         return window.frame
     }
 
+    /// Reassert the panel's Space membership after Mission Control switches
+    /// Spaces. macOS can keep an ordered window marked as visible while it is
+    /// no longer frontmost in the newly active Space.
+    func reassertForActiveSpace() {
+        guard let window else { return }
+        window.collectionBehavior = Self.allSpacesCollectionBehavior
+        guard window.isVisible else { return }
+        window.orderFrontRegardless()
+    }
+
     func show(at anchor: CGPoint, makeKey: Bool = false) {
         guard let window else { return }
         lastAnchor = anchor
+        let wasVisible = window.isVisible
 
-        if !window.isVisible {
+        if !wasVisible {
             hostingView.rootView = overlayRootView(
                 paragraphOverlayMaxHeight: currentParagraphOverlayMaxHeight,
                 paragraphOverlayScrollingEnabled: currentParagraphOverlayScrollingEnabled
@@ -1252,16 +1269,21 @@ final class OverlayWindowController: NSWindowController {
         }
 
         let targetFrame = measuredFrame(for: anchor)
+        window.collectionBehavior = Self.allSpacesCollectionBehavior
 
-        if !window.isVisible {
+        if !wasVisible {
             cancelParagraphFrameAnimation()
             window.setFrame(targetFrame, display: true)
-            window.orderFrontRegardless()
-            if makeKey {
-                window.makeKey()
-            }
         } else {
             applyFrameIfNeeded(targetFrame)
+        }
+
+        // Reorder even when AppKit reports the window as visible. During a
+        // Space switch that state can refer to the previous Space, which used
+        // to make the overlay silently remain there.
+        window.orderFrontRegardless()
+        if makeKey {
+            window.makeKey()
         }
     }
 


### PR DESCRIPTION
## What changed
- Reassert the translation overlay after NSWorkspace.activeSpaceDidChangeNotification.
- Reapply all-Spaces window behavior and orderFrontRegardless() when showing an overlay.
- Invalidate the capture cache when the active Space changes.

## Why
On macOS, AppKit can keep the panel marked visible after switching Spaces even though it is no longer frontmost in the active Space. That caused the overlay to be updated without being ordered in the current Space.

## Validation
- git diff --check
- Release arm64 build with Xcode 26.6 succeeded using local ad-hoc signing.